### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/nixes/fabric/lock.json
+++ b/nixes/fabric/lock.json
@@ -1093,11 +1093,11 @@
         "url": "https://files.pythonhosted.org/packages/13/68/8906226b15ef38e71dc926c321d2fe99de8048e9098b5dfd38343011c886/pyasn1_modules-0.4.0-py3-none-any.whl",
         "version": "0.4.0"
       },
-      "pyautogen": {
+      "ag2": {
         "is_direct": false,
         "sha256": "69dffa4053096f496a50c8a252bbe23105b58fd6ffbb422fa8c043ecf3fc732b",
         "type": "url",
-        "url": "https://files.pythonhosted.org/packages/28/54/c98a6edbd57b17ee42aee9f51e41f20c87458870abcf02eb2dc0fccba428/pyautogen-0.2.28-py3-none-any.whl",
+        "url": "https://files.pythonhosted.org/packages/28/54/c98a6edbd57b17ee42aee9f51e41f20c87458870abcf02eb2dc0fccba428/ag2-0.2.28-py3-none-any.whl",
         "version": "0.2.28"
       },
       "pycparser": {
@@ -2350,7 +2350,7 @@
           "flask",
           "gradio",
           "markdown",
-          "pyautogen",
+          "ag2",
           "rich"
         ],
         "proto-plus": [
@@ -2368,7 +2368,7 @@
         "pyasn1-modules": [
           "pyasn1"
         ],
-        "pyautogen": [
+        "ag2": [
           "diskcache",
           "docker",
           "flaml",


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
